### PR TITLE
Implement version history

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   </div>
   <section id="versions">
     <h2>Past Versions</h2>
-    <ul>
+    <ul id="versions-list">
       <!-- Versions will appear here -->
     </ul>
   </section>

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,52 @@
 
 (function () {
   let menu = null;
+  const editor = document.getElementById('editor');
+
+  function getVersions() {
+    try {
+      return JSON.parse(localStorage.getItem('versions')) || [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function storeVersions(versions) {
+    localStorage.setItem('versions', JSON.stringify(versions));
+  }
+
+  function updateVersionList() {
+    const versions = getVersions();
+    const ul = document.getElementById('versions-list');
+    if (!ul) return;
+    ul.innerHTML = '';
+    versions.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      ul.appendChild(li);
+    });
+  }
+
+  function saveVersion() {
+    const text = editor.innerText;
+    const versions = getVersions();
+    if (versions.length === 0 || versions[versions.length - 1] !== text) {
+      versions.push(text);
+      storeVersions(versions);
+      updateVersionList();
+    }
+  }
+
+  function setupVersionTracking() {
+    updateVersionList();
+    let timer;
+    editor.addEventListener('input', () => {
+      clearTimeout(timer);
+      timer = setTimeout(saveVersion, 300);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', setupVersionTracking);
 
   function getApiKey() {
     let key = sessionStorage.getItem('geminiApiKey');
@@ -84,6 +130,7 @@
           if (suggestion) {
             range.deleteContents();
             range.insertNode(document.createTextNode(suggestion));
+            saveVersion();
           }
         } catch (err) {
           alert(err.message);


### PR DESCRIPTION
## Summary
- persist editor history in localStorage
- show existing versions on page load
- capture AI suggestions as new versions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849eeb08438832e8f9dadbe2ba5669b